### PR TITLE
Fix external urls in accessibility texts

### DIFF
--- a/i18n/accessibility-info/accessibility.en.md
+++ b/i18n/accessibility-info/accessibility.en.md
@@ -49,17 +49,17 @@ Virheellisten toimintojen korjaukset edellyttävät uuden moduulin rakentamista.
 
 ## Huomasitko saavutettavuuspuutteen digipalvelussamme? Kerro se meille ja teemme parhaamme puutteen korjaamiseksi
 
-[Anna saavutettavuuspalautetta tällä verkkolomakkeella](https://opaskartta.turku.fi/eFeedback/fi/Feedback/87/1047)
+<a href="https://opaskartta.turku.fi/eFeedback/fi/Feedback/87/1047" target="_blank">Anna saavutettavuuspalautetta tällä verkkolomakkeella</a>
 
 ## Valvontaviranomainen
 
-Jos huomaat sivustolla saavutettavuusongelmia, anna ensin palautetta meille eli sivuston ylläpitäjälle. Vastauksessa voi mennä 14 päivää. Jos et ole tyytyväinen saamaasi vastaukseen tai et saa vastausta lainkaan kahden viikon aikana, [voit tehdä ilmoituksen Etelä-Suomen aluehallintovirastoon](https://www.saavutettavuusvaatimukset.fi/oikeutesi/). Etelä-Suomen aluehallintoviraston sivulla kerrotaan tarkasti, miten ilmoituksen voi tehdä ja miten asia käsitellään.
+Jos huomaat sivustolla saavutettavuusongelmia, anna ensin palautetta meille eli sivuston ylläpitäjälle. Vastauksessa voi mennä 14 päivää. Jos et ole tyytyväinen saamaasi vastaukseen tai et saa vastausta lainkaan kahden viikon aikana, <a href="https://www.saavutettavuusvaatimukset.fi/oikeutesi/" target="_blank">voit tehdä ilmoituksen Etelä-Suomen aluehallintovirastoon</a>. Etelä-Suomen aluehallintoviraston sivulla kerrotaan tarkasti, miten ilmoituksen voi tehdä ja miten asia käsitellään.
 
 ### Valvontaviranomaisen yhteystiedot
 
 Etelä-Suomen aluehallintovirasto  
 Saavutettavuuden valvonnan yksikkö  
-www.saavutettavuusvaatimukset.fi  
+<a href="https://www.saavutettavuusvaatimukset.fi" target="_blank">www.saavutettavuusvaatimukset.fi</a>  
 saavutettavuus(at)avi.fi  
 puhelinnumero vaihde 0295 016 000
 

--- a/i18n/accessibility-info/accessibility.fi.md
+++ b/i18n/accessibility-info/accessibility.fi.md
@@ -49,17 +49,17 @@ Virheellisten toimintojen korjaukset edellyttävät uuden moduulin rakentamista.
 
 ## Huomasitko saavutettavuuspuutteen digipalvelussamme? Kerro se meille ja teemme parhaamme puutteen korjaamiseksi
 
-[Anna saavutettavuuspalautetta tällä verkkolomakkeella](https://opaskartta.turku.fi/eFeedback/fi/Feedback/87/1047)
+<a href="https://opaskartta.turku.fi/eFeedback/fi/Feedback/87/1047" target="_blank">Anna saavutettavuuspalautetta tällä verkkolomakkeella</a>
 
 ## Valvontaviranomainen
 
-Jos huomaat sivustolla saavutettavuusongelmia, anna ensin palautetta meille eli sivuston ylläpitäjälle. Vastauksessa voi mennä 14 päivää. Jos et ole tyytyväinen saamaasi vastaukseen tai et saa vastausta lainkaan kahden viikon aikana, [voit tehdä ilmoituksen Etelä-Suomen aluehallintovirastoon](https://www.saavutettavuusvaatimukset.fi/oikeutesi/). Etelä-Suomen aluehallintoviraston sivulla kerrotaan tarkasti, miten ilmoituksen voi tehdä ja miten asia käsitellään.
+Jos huomaat sivustolla saavutettavuusongelmia, anna ensin palautetta meille eli sivuston ylläpitäjälle. Vastauksessa voi mennä 14 päivää. Jos et ole tyytyväinen saamaasi vastaukseen tai et saa vastausta lainkaan kahden viikon aikana, <a href="https://www.saavutettavuusvaatimukset.fi/oikeutesi/" target="_blank">voit tehdä ilmoituksen Etelä-Suomen aluehallintovirastoon</a>. Etelä-Suomen aluehallintoviraston sivulla kerrotaan tarkasti, miten ilmoituksen voi tehdä ja miten asia käsitellään.
 
 ### Valvontaviranomaisen yhteystiedot
 
 Etelä-Suomen aluehallintovirasto  
 Saavutettavuuden valvonnan yksikkö  
-www.saavutettavuusvaatimukset.fi  
+<a href="https://www.saavutettavuusvaatimukset.fi" target="_blank">www.saavutettavuusvaatimukset.fi</a>  
 saavutettavuus(at)avi.fi  
 puhelinnumero vaihde 0295 016 000
 

--- a/i18n/accessibility-info/accessibility.sv.md
+++ b/i18n/accessibility-info/accessibility.sv.md
@@ -49,17 +49,17 @@ Följande innehåll och/eller funktioner är inte tillgängliga på grund av und
 
 ## Upptäckte du en tillgänglighetsbrist i vår digitala tjänst? Beskriv den för oss och vi ska göra vårt bästa för att åtgärda den
 
-[Ge tillgänglighetsrespons på detta webbformulär](https://opaskartta.turku.fi/eFeedback/sv/Feedback/87/1047)
+<a href="https://opaskartta.turku.fi/eFeedback/sv/Feedback/87/1047" target="_blank">Ge tillgänglighetsrespons på detta webbformulär</a>
 
 ## Tillsynsmyndigheten
 
-Kontakta oss om du vill påtala brister i tillgängligheten på vår webbplats. Det kan ta 14 dagar innan du får ett svar. Om du inte är nöjd med det svar du har fått eller inte får något svar alls inom två veckor [kan du lämna in en anmälan om bristande tillgänglighet till Regionförvaltningsverket i Södra Finland](https://www.xn--tillgnglighetskrav-ptb.fi/dina-rattigheter/). På regionförvaltningsverkets webbplats finns det beskrivet hur du kan lämna in en anmälan och hur ärendet behandlas.
+Kontakta oss om du vill påtala brister i tillgängligheten på vår webbplats. Det kan ta 14 dagar innan du får ett svar. Om du inte är nöjd med det svar du har fått eller inte får något svar alls inom två veckor <a href="https://www.xn--tillgnglighetskrav-ptb.fi/dina-rattigheter/" target="_blank">kan du lämna in en anmälan om bristande tillgänglighet till Regionförvaltningsverket i Södra Finland</a>. På regionförvaltningsverkets webbplats finns det beskrivet hur du kan lämna in en anmälan och hur ärendet behandlas.
 
 ### Tillsynsmyndighetens kontaktuppgifter
 
 Regionförvaltningsverket i Södra Finland  
 Enheten för tillgänglighetstillsyn  
-www.tillgänglighetskrav.fi  
+<a href="https://www.tillgänglighetskrav.fi" target="_blank">www.tillgänglighetskrav.fi</a>  
 webbtillganglighet@rfv.fi  
 telefonnummer växeln 0295 016 000
 


### PR DESCRIPTION
In external URLs target="_blank" adds the icon to after the link texts.