### PR TITLE
post-install script to move matomo.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ Development steps:
         /kerrokantasi-ui-turku
       ```
 2. In the `kerrokantasi-ui` project run `yarn add ../kerrokantasi-ui-turku`
+   1. Once the package has been added, a post-install script will attempt to copy `assets/js/tracker/matomo.js`
+   from `kerrokantasi-ui-turku` into `kerrokantasi-ui` `assets/js/tracker/matomo.js`.
+   The `kerrokantasi-ui` `tracker` folder is created if it doesn't exist and `tracker/matomo.js` is replaced if it already exists.
+   If this script doesn't work then the copy operations must be done manually.
 3. Edit files in `kerrokantasi-ui/node_modules/kerrokantasi-ui-turku` for changes to be reflected
 
 
@@ -36,3 +40,6 @@ Run: `yarn build-favicons`
 City specific tracking/analytics code such as Matomo or Piwik must be added directly
  in `kerrokantasi-ui` project under `/assets/js/tracker` folder. Currently this 
  project's `urls.json`'s analytics url points to path `/assets/js/tracker/matomo.js`.
+
+A post-install(runs after package has been added) script will copy `/assets/js/tracker/matomo.js` directly into `kerrokantasi-ui`
+`/assets/js/tracker` creating the `tracker` folder if it doesn't exist and replacing `matomo.js` if it already exists.

--- a/assets/urls.json
+++ b/assets/urls.json
@@ -6,6 +6,6 @@
   "feedbackSV": "https://opaskartta.turku.fi/eFeedback/sv/Feedback/30/1121",
   "rasterMapTiles": "https://maptiles.turku.fi/styles/hel-osm-bright/{z}/{x}/{y}@2x.png",
   "highContrastRasterMapTiles": "https://maptiles.turku.fi/styles/hel-osm-high-contrast/{z}/{x}/{y}.png",
-  "city": "http://www.turku.fi",
-  "analytics": "/assets/js/tracker/matomo.js"
+  "city": "https://www.turku.fi",
+  "analytics": "/assets/js/matomo.js"
 }

--- a/assets/urls.json
+++ b/assets/urls.json
@@ -7,5 +7,5 @@
   "rasterMapTiles": "https://maptiles.turku.fi/styles/hel-osm-bright/{z}/{x}/{y}@2x.png",
   "highContrastRasterMapTiles": "https://maptiles.turku.fi/styles/hel-osm-high-contrast/{z}/{x}/{y}.png",
   "city": "https://www.turku.fi",
-  "analytics": "/assets/js/matomo.js"
+  "analytics": "/assets/js/tracker/matomo.js"
 }

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "kerrokantasi-ui-turku",
   "version": "0.0.1",
   "scripts": {
+    "postinstall": "node ./scripts/copy-matomo.js",
     "build-favicons": "node ./scripts/favicon-generator.js"
   },
   "repository": {

--- a/scripts/copy-matomo.js
+++ b/scripts/copy-matomo.js
@@ -1,0 +1,33 @@
+const fs = require('fs');
+const path = require('path');
+/**
+ * Path to matomo.js that will be copied to base kerrokantasi-ui.
+ * @example ./assets/js/tracker/matomo.js
+ * @type {string}
+ */
+const source = path.resolve(__dirname,'../assets/js/tracker/matomo.js');
+/**
+ * Path to destination folder that the matomo.js file will be copied to.
+ * @example kerrokantasi-ui/assets/js
+ * @type {string}
+ */
+const destination = path.resolve(__dirname, '../../../assets/js');
+
+/**
+ * Make sure that destination exists, is readable and writeable.
+ */
+fs.access(destination, fs.constants.F_OK | fs.constants.R_OK | fs.constants.W_OK, (err) => {
+    if (err){console.error(err);}
+    else {CopyMatomoJS();}
+});
+
+/**
+ * Copy matomo.js from theme-package to kerrokantasi-ui.
+ */
+function CopyMatomoJS() {
+    fs.copyFile(source, destination + '/matomo.js', (err) => {
+        if (err) throw err;
+        console.log(`matomo.js successfully copied from: ${source} to ${destination}`);
+    });
+}
+

--- a/scripts/copy-matomo.js
+++ b/scripts/copy-matomo.js
@@ -6,23 +6,42 @@ const path = require('path');
  * @type {string}
  */
 const source = path.resolve(__dirname,'../assets/js/tracker/matomo.js');
+
 /**
  * Path to destination folder that the matomo.js file will be copied to.
  * @example kerrokantasi-ui/assets/js
  * @type {string}
  */
-const destination = path.resolve(__dirname, '../../../assets/js');
+const destination = path.resolve(__dirname, '../../../assets/js/tracker');
 
 /**
- * Make sure that destination exists, is readable and writeable.
+ * Creates the destination folder.
  */
-fs.access(destination, fs.constants.F_OK | fs.constants.R_OK | fs.constants.W_OK, (err) => {
-    if (err){console.error(err);}
-    else {CopyMatomoJS();}
+fs.mkdir(destination, {recursive: false}, (err) => {
+    if (err) {
+        // destination folder already exists, so we can proceed to the next step.
+        if (err.code === 'EEXIST') {checkAccess();}
+        // some other error occurred.
+        else {console.error(err);}
+    } else {
+        // no errors occurred, destination was created successfully, we proceed to next step.
+        checkAccess();
+    }
 });
 
 /**
- * Copy matomo.js from theme-package to kerrokantasi-ui.
+ * Checks if destination exists, is readable and writable.
+ * If all are true then we proceed to actually copying the matomo file.
+ */
+function checkAccess() {
+    fs.access(destination, fs.constants.F_OK | fs.constants.R_OK | fs.constants.W_OK, (err) => {
+        if (err){console.error(err);}
+        else {CopyMatomoJS();}
+    });
+}
+
+/**
+ * Copy matomo.js from theme-package to destination in kerrokantasi-ui project files.
  */
 function CopyMatomoJS() {
     fs.copyFile(source, destination + '/matomo.js', (err) => {


### PR DESCRIPTION
Changes:

- Added a post-install(runs after package is added) script that will attempt to copy `assets/js/tracker/matomo.js` from this package into kerrokantasi-ui base project `assets/js/tracker/`. If `tracker` folder doesn't exist it is created before copying and if `matomo.js` already exists then it is replaced.
- Updated urls.json city url to use https instead of plain http