### PR TITLE
Changed high contast map tile URL

### DIFF
--- a/assets/urls.json
+++ b/assets/urls.json
@@ -5,7 +5,7 @@
   "feedbackFI": "https://opaskartta.turku.fi/eFeedback/fi/Feedback/30/1121",
   "feedbackSV": "https://opaskartta.turku.fi/eFeedback/sv/Feedback/30/1121",
   "rasterMapTiles": "https://maptiles.turku.fi/styles/hel-osm-bright/{z}/{x}/{y}@2x.png",
-  "highContrastRasterMapTiles": "https://maptiles.turku.fi/styles/hel-osm-high-contrast/{z}/{x}/{y}.png",
+  "highContrastRasterMapTiles": "https://maptiles.turku.fi/styles/high-contrast-map-layer/{z}/{x}/{y}.png",
   "city": "https://www.turku.fi",
   "analytics": "/assets/js/tracker/matomo.js"
 }


### PR DESCRIPTION
# New high contrast map tile URL

## Changed the high contrast map tile URL to new one

### [Related Trello card](https://trello.com/c/DMwmFnej)

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Map tile url
 1. assets/urls.json
     * changed the high contrast map tile url